### PR TITLE
Replace empty env dict with the current environment variables

### DIFF
--- a/src/butter_backup/device_managers.py
+++ b/src/butter_backup/device_managers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import subprocess
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -12,7 +13,7 @@ from butter_backup import shell_interface as sh
 def decrypted_device(device: Path, map_name: str, pass_cmd: str):
     decrypt_cmd: sh.StrPathList = ["sudo", "cryptsetup", "open", device, map_name]
     close_cmd = ["sudo", "cryptsetup", "close", map_name]
-    empty_env: dict[str, str] = {}  # make mypy happy
+    empty_env = os.environ
     pwd_proc = subprocess.run(pass_cmd, stdout=subprocess.PIPE, shell=True, check=True)
     subprocess.run(decrypt_cmd, input=pwd_proc.stdout, check=True, env=empty_env)
     yield Path(f"/dev/mapper/{map_name}")

--- a/src/butter_backup/shell_interface.py
+++ b/src/butter_backup/shell_interface.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 from typing import List, Optional, Union
@@ -18,11 +19,11 @@ class ShellInterfaceError(ValueError):
 def run_cmd(
     *,
     cmd: _CMD_LIST,
-    env: Optional[dict[str, str]] = None,
+    env: Optional[Union[dict[str, str], os._Environ[str]]] = None,
     capture_output: bool = False
 ) -> subprocess.CompletedProcess:
     if env is None:
-        env = {}
+        env = os.environ
     result = subprocess.run(cmd, capture_output=capture_output, check=True, env=env)
     return result
 
@@ -30,11 +31,11 @@ def run_cmd(
 def run_piped_commands(
     *,
     cmds: _LISTS_OF_CMD_LIST,
-    env: Optional[dict[str, str]] = None,
+    env: Optional[Union[dict[str, str], os._Environ[str]]] = None,
     capture_output: bool = False
 ) -> subprocess.CompletedProcess:
     if env is None:
-        env = {}
+        env = os.environ
     if len(cmds) < 2:
         raise ShellInterfaceError("Mindestens zwei Shell-Kommandos erwartet!")
 


### PR DESCRIPTION
I encountered several issues when the `env` variable was just an empty dictionary. Both the backup and multiple tests were failing for me. I therefore replaced the default value with the current environment variables of the system. Could you please verify that this produces the expected behavior?