### PR TITLE
Update arch docker image

### DIFF
--- a/docker-images/arch
+++ b/docker-images/arch
@@ -11,7 +11,7 @@ RUN pacman -Syu --noconfirm
 RUN pacman -S --noconfirm btrfs-progs cryptsetup curl make python python-pip sudo
 
 # Setup Poetry
-ENV POETRY_VERSION=1.1.11
+ENV POETRY_VERSION=1.1.13
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/$POETRY_VERSION/get-poetry.py | python -
 ENV PATH=$PATH:/root/.poetry/bin
 

--- a/docker-images/arch
+++ b/docker-images/arch
@@ -20,7 +20,7 @@ ENV PATH=$PATH:/root/.poetry/bin
 WORKDIR /project
 COPY pyproject.toml poetry.lock ./
 RUN --mount=type=cache,target=/root/.cache/pip \
-    poetry export --dev > requirements.txt \
+    poetry export --without-hashes --dev > requirements.txt \
     && python3 -m pip install -r requirements.txt \
     && rm requirements.txt
 

--- a/docker-images/arch
+++ b/docker-images/arch
@@ -1,8 +1,14 @@
 # archlinux:base as of Oct. 25th, 2021
 FROM archlinux@sha256:04d0ec982fe298e0a8fbda48461945c8ed6f0b24dc12492e68b31eac576fc327
 
+RUN pacman -Syy --noconfirm archlinux-keyring
+RUN rm -fr /etc/pacman.d/gnupg
+RUN pacman-key --init
+RUN pacman-key --populate archlinux
+
 # Provide relevant binaries
-RUN pacman -Syy --noconfirm btrfs-progs cryptsetup curl make python python-pip sudo
+RUN pacman -Syu --noconfirm 
+RUN pacman -S --noconfirm btrfs-progs cryptsetup curl make python python-pip sudo
 
 # Setup Poetry
 ENV POETRY_VERSION=1.1.11


### PR DESCRIPTION
This PR fixes the tests on the arch docker images (for me) -- which would otherwise fail.

Exporting the dependencies without hashes (45811ed400f920ba36046d60b195e6fbf8d6143e) could maybe lead to unfortunate consequences (but is required as otherwise the `poetry` <=> `pip` interplay does not allow to install `butter-backup`).