### PR TITLE
sdm: Generalise all applicable tests to BtrFS and Ext4 and different compressions

### DIFF
--- a/projects/storage-device-managers/src/storage_device_managers/__init__.py
+++ b/projects/storage-device-managers/src/storage_device_managers/__init__.py
@@ -40,7 +40,6 @@ __all__ = [
     "get_mounted_devices",
     "is_mounted",
     "mkfs",
-    "mkfs_ext4",
     "mount_btrfs_device",
     "mount_device",
     "mount_ext4_device",
@@ -601,7 +600,7 @@ def _mkfs_btrfs(device: Path) -> None:
     sh.run_cmd(cmd=cmd)
 
 
-def mkfs_ext4(device: Path) -> None:
+def _mkfs_ext4(device: Path) -> None:
     """Format device with ext4
 
     Parameters:
@@ -631,7 +630,7 @@ def mkfs(device: Path, filesystem: ValidFileSystems) -> None:
         case "btrfs":
             _mkfs_btrfs(device)
         case "ext4":
-            mkfs_ext4(device)
+            _mkfs_ext4(device)
         case _:
             t.assert_never(filesystem)
 

--- a/projects/storage-device-managers/src/storage_device_managers/__init__.py
+++ b/projects/storage-device-managers/src/storage_device_managers/__init__.py
@@ -40,7 +40,6 @@ __all__ = [
     "get_mounted_devices",
     "is_mounted",
     "mkfs",
-    "mount_btrfs_device",
     "mount_device",
     "mount_ext4_device",
     "mounted_device",
@@ -252,7 +251,7 @@ def symbolic_link(src: Path, dest: Path) -> Iterator[Path]:
         logger.success(f"Symlink von {src} nach {dest} erfolgreich entfernt.")
 
 
-def mount_btrfs_device(
+def _mount_btrfs_device(
     device: Path, mount_dir: Path, compression: ValidCompressions | None = None
 ) -> None:
     """
@@ -330,7 +329,7 @@ def mount_device(
     fs = get_filesystem(device)
     match fs:
         case "btrfs":
-            mount_btrfs_device(device, mount_dir, compression)
+            _mount_btrfs_device(device, mount_dir, compression)
         case "ext4":
             mount_ext4_device(device, mount_dir)
         case _:

--- a/projects/storage-device-managers/src/storage_device_managers/__init__.py
+++ b/projects/storage-device-managers/src/storage_device_managers/__init__.py
@@ -41,7 +41,6 @@ __all__ = [
     "is_mounted",
     "mkfs",
     "mount_device",
-    "mount_ext4_device",
     "mounted_device",
     "open_encrypted_device",
     "symbolic_link",
@@ -282,7 +281,7 @@ def _mount_btrfs_device(
     sh.run_cmd(cmd=cmd)
 
 
-def mount_ext4_device(device: Path, mount_dir: Path) -> None:
+def _mount_ext4_device(device: Path, mount_dir: Path) -> None:
     """
     Mount a given ext4 device
 
@@ -331,7 +330,7 @@ def mount_device(
         case "btrfs":
             _mount_btrfs_device(device, mount_dir, compression)
         case "ext4":
-            mount_ext4_device(device, mount_dir)
+            _mount_ext4_device(device, mount_dir)
         case _:
             cmd: sh.StrPathList = ["sudo", "mount", device, mount_dir]
             sh.run_cmd(cmd=cmd)

--- a/projects/storage-device-managers/src/storage_device_managers/__init__.py
+++ b/projects/storage-device-managers/src/storage_device_managers/__init__.py
@@ -40,7 +40,6 @@ __all__ = [
     "get_mounted_devices",
     "is_mounted",
     "mkfs",
-    "mkfs_btrfs",
     "mkfs_ext4",
     "mount_btrfs_device",
     "mount_device",
@@ -589,7 +588,7 @@ def get_filesystem(device: Path) -> str:
     return result.stdout.decode().strip()
 
 
-def mkfs_btrfs(device: Path) -> None:
+def _mkfs_btrfs(device: Path) -> None:
     """Format device with BtrFS
 
     Parameters:
@@ -630,7 +629,7 @@ def mkfs(device: Path, filesystem: ValidFileSystems) -> None:
     """
     match filesystem:
         case "btrfs":
-            mkfs_btrfs(device)
+            _mkfs_btrfs(device)
         case "ext4":
             mkfs_ext4(device)
         case _:

--- a/projects/storage-device-managers/tests/conftest.py
+++ b/projects/storage-device-managers/tests/conftest.py
@@ -50,74 +50,36 @@ def big_file(_big_file_persistent: Path):
         yield file
 
 
-@pytest.fixture(scope="session")
-def _encrypted_btrfs_device_persistent(_big_file_persistent):
+@pytest.fixture(scope="session", params=[sdm.mkfs_ext4, sdm.mkfs_btrfs])
+def _encrypted_device_persistent(_big_file_persistent, request):
+    mkfs_func = request.param
     password_cmd = sdm.generate_passcmd()
     with NamedTemporaryFile() as ntf:
-        btrfs_device = Path(ntf.name)
-        shutil.copy(_big_file_persistent, btrfs_device)
-        sdm.encrypt_device(btrfs_device, password_cmd)
-        with sdm.decrypted_device(btrfs_device, password_cmd) as decrypted:
-            sdm.mkfs_btrfs(decrypted)
-        yield btrfs_device, password_cmd
-
-
-@pytest.fixture(scope="session")
-def _encrypted_ext4_device_persistent(_big_file_persistent):
-    password_cmd = sdm.generate_passcmd()
-    with NamedTemporaryFile() as ntf:
-        ext4_device = Path(ntf.name)
-        shutil.copy(_big_file_persistent, ext4_device)
-        sdm.encrypt_device(ext4_device, password_cmd)
-        with sdm.decrypted_device(ext4_device, password_cmd) as decrypted:
-            sdm.mkfs_ext4(decrypted)
-        yield ext4_device, password_cmd
+        device = Path(ntf.name)
+        shutil.copy(_big_file_persistent, device)
+        sdm.encrypt_device(device, password_cmd)
+        with sdm.decrypted_device(device, password_cmd) as decrypted:
+            mkfs_func(decrypted)
+        yield device, password_cmd
 
 
 @pytest.fixture
-def encrypted_btrfs_device(_encrypted_btrfs_device_persistent):
+def encrypted_device(_encrypted_device_persistent):
     """
-    Create encrypted BtrFS file system
+    Create encrypted file system
 
     Returns
     -------
     Path
-        destination of encrypted BtrFS file system
+        destination of encrypted file system
     str
         password command that echos password to STDOUT
     """
-    btrfs_device, pass_cmd = _encrypted_btrfs_device_persistent
+    btrfs_device, pass_cmd = _encrypted_device_persistent
     with NamedTemporaryFile() as ntf:
         file = Path(ntf.name)
         shutil.copy(btrfs_device, file)
         yield file, pass_cmd
-
-
-@pytest.fixture
-def encrypted_ext4_device(_encrypted_ext4_device_persistent):
-    """
-    Create encrypted BtrFS file system
-
-    Returns
-    -------
-    Path
-        destination of encrypted BtrFS file system
-    str
-        password command that echos password to STDOUT
-    """
-    ext4_device, pass_cmd = _encrypted_ext4_device_persistent
-    with NamedTemporaryFile() as ntf:
-        file = Path(ntf.name)
-        shutil.copy(ext4_device, file)
-        yield file, pass_cmd
-
-
-@pytest.fixture(params=["encrypted_btrfs_device", "encrypted_ext4_device"])
-def encrypted_device(request):
-    # As of now, the fixture seems superfluous. However, it is kept in case
-    # support for other file systems is added later on.
-    dest, pass_cmd = request.getfixturevalue(request.param)
-    return dest, pass_cmd
 
 
 @pytest.fixture(scope="session")

--- a/projects/storage-device-managers/tests/conftest.py
+++ b/projects/storage-device-managers/tests/conftest.py
@@ -62,6 +62,18 @@ def _encrypted_btrfs_device_persistent(_big_file_persistent):
         yield btrfs_device, password_cmd
 
 
+@pytest.fixture(scope="session")
+def _encrypted_ext4_device_persistent(_big_file_persistent):
+    password_cmd = sdm.generate_passcmd()
+    with NamedTemporaryFile() as ntf:
+        ext4_device = Path(ntf.name)
+        shutil.copy(_big_file_persistent, ext4_device)
+        sdm.encrypt_device(ext4_device, password_cmd)
+        with sdm.decrypted_device(ext4_device, password_cmd) as decrypted:
+            sdm.mkfs_ext4(decrypted)
+        yield ext4_device, password_cmd
+
+
 @pytest.fixture
 def encrypted_btrfs_device(_encrypted_btrfs_device_persistent):
     """
@@ -81,7 +93,26 @@ def encrypted_btrfs_device(_encrypted_btrfs_device_persistent):
         yield file, pass_cmd
 
 
-@pytest.fixture(params=["encrypted_btrfs_device"])
+@pytest.fixture
+def encrypted_ext4_device(_encrypted_ext4_device_persistent):
+    """
+    Create encrypted BtrFS file system
+
+    Returns
+    -------
+    Path
+        destination of encrypted BtrFS file system
+    str
+        password command that echos password to STDOUT
+    """
+    ext4_device, pass_cmd = _encrypted_ext4_device_persistent
+    with NamedTemporaryFile() as ntf:
+        file = Path(ntf.name)
+        shutil.copy(ext4_device, file)
+        yield file, pass_cmd
+
+
+@pytest.fixture(params=["encrypted_btrfs_device", "encrypted_ext4_device"])
 def encrypted_device(request):
     # As of now, the fixture seems superfluous. However, it is kept in case
     # support for other file systems is added later on.

--- a/projects/storage-device-managers/tests/conftest.py
+++ b/projects/storage-device-managers/tests/conftest.py
@@ -105,7 +105,7 @@ def _ext4_device_persistent(_big_file_persistent):
     with NamedTemporaryFile() as ntf:
         ext4_device = Path(ntf.name)
         shutil.copy(_big_file_persistent, ext4_device)
-        sdm.mkfs_ext4(ext4_device)
+        sdm._mkfs_ext4(ext4_device)
         yield ext4_device
 
 

--- a/projects/storage-device-managers/tests/conftest.py
+++ b/projects/storage-device-managers/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+import typing as t
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
@@ -50,16 +51,16 @@ def big_file(_big_file_persistent: Path):
         yield file
 
 
-@pytest.fixture(scope="session", params=[sdm.mkfs_ext4, sdm.mkfs_btrfs])
+@pytest.fixture(scope="session", params=t.get_args(sdm.ValidFileSystems))
 def _encrypted_device_persistent(_big_file_persistent, request):
-    mkfs_func = request.param
+    file_system: sdm.ValidFileSystems = request.param
     password_cmd = sdm.generate_passcmd()
     with NamedTemporaryFile() as ntf:
         device = Path(ntf.name)
         shutil.copy(_big_file_persistent, device)
         sdm.encrypt_device(device, password_cmd)
         with sdm.decrypted_device(device, password_cmd) as decrypted:
-            mkfs_func(decrypted)
+            sdm.mkfs(decrypted, file_system)
         yield device, password_cmd
 
 
@@ -87,7 +88,7 @@ def _btrfs_device_persistent(_big_file_persistent):
     with NamedTemporaryFile() as ntf:
         btrfs_device = Path(ntf.name)
         shutil.copy(_big_file_persistent, btrfs_device)
-        sdm.mkfs_btrfs(btrfs_device)
+        sdm.mkfs(btrfs_device, "btrfs")
         yield btrfs_device
 
 

--- a/projects/storage-device-managers/tests/test_mkfs.py
+++ b/projects/storage-device-managers/tests/test_mkfs.py
@@ -7,14 +7,6 @@ import pytest
 import storage_device_managers as sdm
 
 
-@pytest.mark.parametrize(
-    "mkfs_func,name", [(sdm.mkfs_btrfs, "btrfs"), (sdm.mkfs_ext4, "ext4")]
-)
-def test_mkfs_ext4(big_file, mkfs_func, name) -> None:
-    mkfs_func(big_file)
-    assert sdm.get_filesystem(big_file) == name
-
-
 @pytest.mark.parametrize("filesystem", t.get_args(sdm.ValidFileSystems))
 def test_mkfs(big_file, filesystem) -> None:
     sdm.mkfs(big_file, filesystem)

--- a/projects/storage-device-managers/tests/test_mkfs.py
+++ b/projects/storage-device-managers/tests/test_mkfs.py
@@ -7,9 +7,12 @@ import pytest
 import storage_device_managers as sdm
 
 
-def test_mkfs_ext4(big_file) -> None:
-    sdm.mkfs_ext4(big_file)
-    assert sdm.get_filesystem(big_file) == "ext4"
+@pytest.mark.parametrize(
+    "mkfs_func,name", [(sdm.mkfs_btrfs, "btrfs"), (sdm.mkfs_ext4, "ext4")]
+)
+def test_mkfs_ext4(big_file, mkfs_func, name) -> None:
+    mkfs_func(big_file)
+    assert sdm.get_filesystem(big_file) == name
 
 
 @pytest.mark.parametrize("filesystem", t.get_args(sdm.ValidFileSystems))

--- a/projects/storage-device-managers/tests/test_mount_unmount.py
+++ b/projects/storage-device-managers/tests/test_mount_unmount.py
@@ -39,15 +39,16 @@ def test_mount_device(device_with_fs) -> None:
 
 
 @pytest.mark.parametrize("args", [[], [sdm.ValidCompressions.ZSTD9]])
-def test_mounted_device_without_compression(btrfs_device, args) -> None:
-    with sdm.mounted_device(btrfs_device, *args) as md:
+def test_mounted_device(device_with_fs, args) -> None:
+    device, _ = device_with_fs
+    with sdm.mounted_device(device, *args) as md:
         assert md.exists()
         assert md.is_dir()
-        assert sdm.is_mounted(btrfs_device)
-        assert md in sdm.get_mounted_devices()[str(btrfs_device)]
+        assert sdm.is_mounted(device)
+        assert md in sdm.get_mounted_devices()[str(device)]
     assert not md.exists()
-    assert not sdm.is_mounted(btrfs_device)
-    assert str(btrfs_device) not in sdm.get_mounted_devices()
+    assert not sdm.is_mounted(device)
+    assert str(device) not in sdm.get_mounted_devices()
 
 
 def test_mounted_device_takes_over_already_mounted_device(btrfs_device) -> None:

--- a/projects/storage-device-managers/tests/test_mount_unmount.py
+++ b/projects/storage-device-managers/tests/test_mount_unmount.py
@@ -9,6 +9,20 @@ import shell_interface as sh
 import storage_device_managers as sdm
 
 
+@pytest.fixture(
+    params=[
+        [],
+        [sdm.ValidCompressions.ZSTD9],
+        [sdm.ValidCompressions.ZLIB1],
+        [None],
+    ]
+)
+def compression_args(request) -> list[sdm.ValidCompressions]:
+    args: list[sdm.ValidCompressions] = request.param
+    return args
+
+
+@pytest.mark.parametrize("args", [[], [sdm.ValidCompressions.ZSTD9]])
 def in_docker_container() -> bool:
     return Path("/.dockerenv").exists()
 
@@ -17,21 +31,20 @@ class MyCustomTestException(Exception):
     pass
 
 
-def test_mount_device(device_with_fs) -> None:
+def test_mount_device(device_with_fs, compression_args) -> None:
     device, _ = device_with_fs
     with TemporaryDirectory() as mount_dir:
         mount_path = Path(mount_dir)
-        sdm.mount_device(device, mount_path)
+        sdm.mount_device(device, mount_path, *compression_args)
         assert sdm.is_mounted(device)
         assert mount_path in sdm.get_mounted_devices()[str(device)]
         sdm.unmount_device(device)
         assert not sdm.is_mounted(device)
 
 
-@pytest.mark.parametrize("args", [[], [sdm.ValidCompressions.ZSTD9]])
-def test_mounted_device(device_with_fs, args) -> None:
+def test_mounted_device(device_with_fs, compression_args) -> None:
     device, _ = device_with_fs
-    with sdm.mounted_device(device, *args) as md:
+    with sdm.mounted_device(device, *compression_args) as md:
         assert md.exists()
         assert md.is_dir()
         assert sdm.is_mounted(device)
@@ -41,12 +54,13 @@ def test_mounted_device(device_with_fs, args) -> None:
     assert str(device) not in sdm.get_mounted_devices()
 
 
-def test_mounted_device_takes_over_already_mounted_device(device_with_fs) -> None:
+def test_mounted_device_takes_over_already_mounted_device(
+    device_with_fs, compression_args
+) -> None:
     device, _ = device_with_fs
-    compression = sdm.ValidCompressions.LZO
     with TemporaryDirectory() as td:
-        sdm.mount_device(device, Path(td), compression)
-        with sdm.mounted_device(device, compression) as md:
+        sdm.mount_device(device, Path(td), *compression_args)
+        with sdm.mounted_device(device, *compression_args) as md:
             assert sdm.is_mounted(device)
             assert md in sdm.get_mounted_devices()[str(device)]
         assert not sdm.is_mounted(device)
@@ -68,15 +82,18 @@ def test_mounted_device_fails_on_not_unmountable_device() -> None:
             pass
 
 
-def test_mounted_device_unmounts_in_case_of_exception(btrfs_device) -> None:
+def test_mounted_device_unmounts_in_case_of_exception(
+    device_with_fs, compression_args
+) -> None:
+    device, _ = device_with_fs
     with pytest.raises(MyCustomTestException):
-        with sdm.mounted_device(btrfs_device, sdm.ValidCompressions.ZLIB1) as md:
+        with sdm.mounted_device(device, *compression_args) as md:
             # That the device is mounted properly is guaranteed by a test
             # above.
             raise MyCustomTestException
-    assert not sdm.is_mounted(btrfs_device), "Device is still mounted after exception."
+    assert not sdm.is_mounted(device), "Device is still mounted after exception."
     assert not md.exists(), "Mounted device still exists after exception."
-    assert str(btrfs_device) not in sdm.get_mounted_devices()
+    assert str(device) not in sdm.get_mounted_devices()
 
 
 @pytest.mark.parametrize("device", sdm.get_mounted_devices())
@@ -89,11 +106,12 @@ def test_is_mounted_rejects() -> None:
         assert not sdm.is_mounted(Path(tempd))
 
 
-def test_unmount_device(btrfs_device) -> None:
+def test_unmount_device(device_with_fs) -> None:
+    device, _ = device_with_fs
     with TemporaryDirectory() as mountpoint:
-        sdm.mount_btrfs_device(btrfs_device, Path(mountpoint))
-        sdm.unmount_device(btrfs_device)
-        assert not sdm.is_mounted(btrfs_device)
+        sdm.mount_device(device, Path(mountpoint))
+        sdm.unmount_device(device)
+        assert not sdm.is_mounted(device)
 
 
 def test_unmount_device_raises_unmounterror() -> None:
@@ -106,9 +124,9 @@ def test_unmount_device_raises_unmounterror() -> None:
 
 
 def test_mounted_device_does_not_delete_content_on_umount_error(
-    btrfs_device, mocker
+    device_with_fs, compression_args, mocker
 ) -> None:
-    compression = sdm.ValidCompressions.ZSTD15
+    device, _ = device_with_fs
     mocker.patch(
         "storage_device_managers.unmount_device",
         side_effect=sdm.UnmountError("Mocked unmount error"),
@@ -116,13 +134,13 @@ def test_mounted_device_does_not_delete_content_on_umount_error(
     user = sh.get_user()
     sentinel_text = "This file should not be deleted."
     with pytest.raises(sdm.UnmountError, match="Mocked unmount error"):
-        with sdm.mounted_device(btrfs_device, compression) as md:
+        with sdm.mounted_device(device, *compression_args) as md:
             sentinel = md / "sentinel-file"
             sdm.chown(md, user, recursive=True)
             sentinel.write_text("This file should not be deleted.")
     assert sentinel.exists(), "Sentinel file was deleted after unmount error."
     assert sentinel.read_text() == sentinel_text
-    assert sdm.is_mounted(btrfs_device)
+    assert sdm.is_mounted(device)
     mocker.stopall()
-    sdm.unmount_device(btrfs_device)
-    assert not sdm.is_mounted(btrfs_device)
+    sdm.unmount_device(device)
+    assert not sdm.is_mounted(device)

--- a/projects/storage-device-managers/tests/test_mount_unmount.py
+++ b/projects/storage-device-managers/tests/test_mount_unmount.py
@@ -17,16 +17,6 @@ class MyCustomTestException(Exception):
     pass
 
 
-def test_mount_ext4_device(ext4_device) -> None:
-    with TemporaryDirectory() as mount_dir:
-        mount_path = Path(mount_dir)
-        sdm.mount_ext4_device(ext4_device, mount_path)
-        assert sdm.is_mounted(ext4_device)
-        assert mount_path in sdm.get_mounted_devices()[str(ext4_device)]
-        sdm.unmount_device(ext4_device)
-        assert not sdm.is_mounted(ext4_device)
-
-
 def test_mount_device(device_with_fs) -> None:
     device, _ = device_with_fs
     with TemporaryDirectory() as mount_dir:

--- a/projects/storage-device-managers/tests/test_mount_unmount.py
+++ b/projects/storage-device-managers/tests/test_mount_unmount.py
@@ -51,14 +51,15 @@ def test_mounted_device(device_with_fs, args) -> None:
     assert str(device) not in sdm.get_mounted_devices()
 
 
-def test_mounted_device_takes_over_already_mounted_device(btrfs_device) -> None:
+def test_mounted_device_takes_over_already_mounted_device(device_with_fs) -> None:
+    device, _ = device_with_fs
     compression = sdm.ValidCompressions.LZO
     with TemporaryDirectory() as td:
-        sdm.mount_btrfs_device(btrfs_device, Path(td), compression)
-        with sdm.mounted_device(btrfs_device, compression) as md:
-            assert sdm.is_mounted(btrfs_device)
-            assert md in sdm.get_mounted_devices()[str(btrfs_device)]
-        assert not sdm.is_mounted(btrfs_device)
+        sdm.mount_device(device, Path(td), compression)
+        with sdm.mounted_device(device, compression) as md:
+            assert sdm.is_mounted(device)
+            assert md in sdm.get_mounted_devices()[str(device)]
+        assert not sdm.is_mounted(device)
 
 
 @pytest.mark.skipif(

--- a/projects/storage-device-managers/tests/test_sync_device.py
+++ b/projects/storage-device-managers/tests/test_sync_device.py
@@ -9,21 +9,23 @@ import shell_interface as sh
 import storage_device_managers as sdm
 
 
-def test_sync_device_is_called_on_unmount(btrfs_device, mocker) -> None:
+def test_sync_device_is_called_on_unmount(device_with_fs, mocker) -> None:
+    device, _ = device_with_fs
     spy = mocker.spy(sdm, "sync_device")
     with TemporaryDirectory() as mount_dir:
-        sdm.mount_btrfs_device(btrfs_device, Path(mount_dir))
-        sdm.unmount_device(btrfs_device)
-    spy.assert_called_once_with(btrfs_device)
+        sdm.mount_device(device, Path(mount_dir))
+        sdm.unmount_device(device)
+    spy.assert_called_once_with(device)
 
 
-def test_sync_device_calls_sync_f_for_btrfs(btrfs_device, mocker) -> None:
+def test_sync_device_calls_sync_f(device_with_fs, mocker) -> None:
+    device, _ = device_with_fs
     with TemporaryDirectory() as mount_dir:
-        sdm.mount_btrfs_device(btrfs_device, Path(mount_dir))
+        sdm.mount_device(device, Path(mount_dir))
         spy = mocker.spy(sh, "run_cmd")
-        sdm.sync_device(btrfs_device)
-        sh.run_cmd(cmd=["sudo", "umount", btrfs_device])
-    assert call(cmd=["sudo", "sync", "-f", btrfs_device]) in spy.call_args_list
+        sdm.sync_device(device)
+        sh.run_cmd(cmd=["sudo", "umount", device])
+    assert call(cmd=["sudo", "sync", "-f", device]) in spy.call_args_list
 
 
 def test_sync_device_calls_btrfs_filesystem_sync_for_btrfs(
@@ -31,7 +33,7 @@ def test_sync_device_calls_btrfs_filesystem_sync_for_btrfs(
 ) -> None:
     with TemporaryDirectory() as mount_dir:
         mount_path = Path(mount_dir)
-        sdm.mount_btrfs_device(btrfs_device, mount_path)
+        sdm.mount_device(btrfs_device, mount_path)
         spy = mocker.spy(sh, "run_cmd")
         sdm.sync_device(btrfs_device)
         sh.run_cmd(cmd=["sudo", "umount", btrfs_device])
@@ -41,18 +43,9 @@ def test_sync_device_calls_btrfs_filesystem_sync_for_btrfs(
     )
 
 
-def test_sync_device_calls_sync_f_for_ext4(ext4_device, mocker) -> None:
-    with TemporaryDirectory() as mount_dir:
-        sdm.mount_ext4_device(ext4_device, Path(mount_dir))
-        spy = mocker.spy(sh, "run_cmd")
-        sdm.sync_device(ext4_device)
-        sh.run_cmd(cmd=["sudo", "umount", ext4_device])
-    assert call(cmd=["sudo", "sync", "-f", ext4_device]) in spy.call_args_list
-
-
 def test_sync_device_does_not_call_btrfs_sync_for_ext4(ext4_device, mocker) -> None:
     with TemporaryDirectory() as mount_dir:
-        sdm.mount_ext4_device(ext4_device, Path(mount_dir))
+        sdm.mount_device(ext4_device, Path(mount_dir))
         spy = mocker.spy(sh, "run_cmd")
         sdm.sync_device(ext4_device)
         sh.run_cmd(cmd=["sudo", "umount", ext4_device])


### PR DESCRIPTION
This MR changes all tests to work on both, BtrFS and ext4 fixtures. This ensures that all supported operations and all desired behaviours hold for both file systems.

Following the same spirit, many tests now are parametrised regarding the file system compression. This ensures that mounting a file system accepts None, various values and skipping passing the argument.

After all that, the file system specific functions are made private. Now the public interface consists of generic functions only.

Make filesystem-specific mount functions private

All tests are extended to cover both BtrFS and ext4 fixtures, ensuring that supported operations and desired behaviours hold for both file systems.

Tests are also parametrised over filesystem compression options, covering None, explicit values, and omitting the argument entirely.

With full test coverage in place, the filesystem-specific functions (mount_btrfs_device, mount_ext4_device) are made private. The public interface now consists of generic functions only.