### PR TITLE
Centralise common tool configuration in project root

### DIFF
--- a/.github/workflows/ci-shell-interface.yml
+++ b/.github/workflows/ci-shell-interface.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check import ordering with ruff
         run: uv run --package shell-interface ruff check --output-format=github --select I projects/shell-interface
       - name: Check static typing with mypy
-        run: uv run --package shell-interface mypy projects/shell-interface
+        run: uv run --group typecheck --package shell-interface mypy projects/shell-interface
       - name: Lint with ruff
         run: uv run --package shell-interface ruff check --output-format=github projects/shell-interface
       - name: Test with pytest

--- a/.github/workflows/ci-storage-device-managers.yml
+++ b/.github/workflows/ci-storage-device-managers.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check import ordering with ruff
         run: uv run --package storage-device-managers ruff check --output-format=github --select I projects/storage-device-managers
       - name: Check static typing with mypy
-        run: uv run --package storage-device-managers mypy projects/storage-device-managers
+        run: uv run --group typecheck --package storage-device-managers mypy projects/storage-device-managers
       - name: Lint with ruff
         run: uv run --package storage-device-managers ruff check --output-format=github projects/storage-device-managers
       - name: Test with pytest

--- a/projects/butter-backup/pyproject.toml
+++ b/projects/butter-backup/pyproject.toml
@@ -43,16 +43,6 @@ dev = [
     "ruff>=0.15.13",
     "types-pyyaml>=6.0.12.20260510",
 ]
-
-
-[tool.pytest.ini_options]
-addopts = [
-    "--cov", "src",
-    "--cov-branch",
-    "--cov-fail-under", "85"
-]
-testpaths = ["tests"]
-
 [tool.pydantic-mypy]
 init_forbid_extra = true
 init_typed = true

--- a/projects/butter-backup/pyproject.toml
+++ b/projects/butter-backup/pyproject.toml
@@ -51,11 +51,7 @@ warn_untyped_fields = true
 
 [tool.ruff]
 src = [".", "src/"]
-
-[tool.ruff.lint]
-select = ["A", "B", "C", "F", "I", "ISC", "PIE", "PL", "Q", "RUF", "SIM", "TID", "W", "YTT"]
-ignore = ["E", "PLC1901", "SIM117"]
-mccabe.max-complexity = 6
+extend = "../../pyproject.toml"
 
 [tool.uv.sources]
 shell-interface = { workspace = true }

--- a/projects/butter-backup/pyproject.toml
+++ b/projects/butter-backup/pyproject.toml
@@ -44,31 +44,6 @@ dev = [
     "types-pyyaml>=6.0.12.20260510",
 ]
 
-[tool.mypy]
-plugins = [
-  "pydantic.mypy"
-]
-allow_any_unimported = false
-warn_unreachable = true
-enable_error_code = [
-    "possibly-undefined"
-]
-strict = true
-allow_incomplete_defs = true
-allow_untyped_defs = true
-
-
-[[tool.mypy.overrides]]
-module = "tests.*"
-disable_error_code = [
-    "possibly-undefined"
-]
-
-[tool.pydantic-mypy]
-init_forbid_extra = true
-init_typed = true
-warn_required_dynamic_aliases = true
-warn_untyped_fields = true
 
 [tool.pytest.ini_options]
 addopts = [
@@ -77,6 +52,12 @@ addopts = [
     "--cov-fail-under", "85"
 ]
 testpaths = ["tests"]
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
+warn_untyped_fields = true
 
 [tool.ruff]
 src = [".", "src/"]

--- a/projects/butter-backup/src/butter_backup/cli.py
+++ b/projects/butter-backup/src/butter_backup/cli.py
@@ -146,7 +146,10 @@ def _open_device(
         _refresh_sudo(sudo_pass_cmd)
         decrypted = sdm.open_encrypted_device(cfg.device(), cfg.DevicePassCmd)
         sdm.mount_device(decrypted, mount_dir=mount_dir, compression=cfg.compression())
-    except:
+    except Exception:
+        # In case of **any** error, the mount dir should be removed to prevent littering
+        # the file system with empty directories. Hence the pokemon style exception
+        # handling.
         typer.echo(
             f"Speichermedium {cfg.Name} konnte nicht geöffnet werden. Es wird übersprungen."
         )

--- a/projects/butter-backup/src/butter_backup/cli.py
+++ b/projects/butter-backup/src/butter_backup/cli.py
@@ -262,13 +262,15 @@ def backup(
             continue
         backend = bb.BackupBackend.from_config(cfg)
         _refresh_sudo(parsed_config.SudoPassCmd)
-        with sdm.decrypted_device(cfg.device(), cfg.DevicePassCmd) as decrypted:
-            with sdm.mounted_device(decrypted, cfg.compression()) as mount_dir:
-                backend.do_backup(mount_dir, parsed_config.SudoPassCmd)
-                # A backup could take so long that the sudo session expires. In this
-                # case the user would have to enter the password again to unmount and
-                # close the device. To prevent this, the sudo session is refreshed.
-                _refresh_sudo(parsed_config.SudoPassCmd)
+        with (
+            sdm.decrypted_device(cfg.device(), cfg.DevicePassCmd) as decrypted,
+            sdm.mounted_device(decrypted, cfg.compression()) as mount_dir,
+        ):
+            backend.do_backup(mount_dir, parsed_config.SudoPassCmd)
+            # A backup could take so long that the sudo session expires. In this
+            # case the user would have to enter the password again to unmount and
+            # close the device. To prevent this, the sudo session is refreshed.
+            _refresh_sudo(parsed_config.SudoPassCmd)
 
 
 @app.command()

--- a/projects/butter-backup/src/butter_backup/config_parser.py
+++ b/projects/butter-backup/src/butter_backup/config_parser.py
@@ -87,7 +87,7 @@ class BaseConfig(BaseModel, abc.ABC):
 
     @field_validator("ExcludePatternsFile", mode="before")
     def expand_tilde_in_exclude_patterns_file_name(
-        cls, maybe_exclude_patterns
+        cls, maybe_exclude_patterns: str | None
     ) -> str | None:
         if maybe_exclude_patterns is None:
             return None
@@ -112,7 +112,7 @@ class BtrFSRsyncConfig(BaseConfig):
     SubvolTimestampFmt: ClassVar[str] = "%F_%H:%M:%S"
 
     @field_validator("Files")
-    def source_file_names_must_be_unique(cls, files):
+    def source_file_names_must_be_unique(cls, files: set[FilePath]) -> set[FilePath]:
         file_names = Counter(f.name for f in files)
         cls.raise_with_message_upon_duplicate(file_names, ("Dateinamen", "Dateinamen"))
         return files
@@ -126,17 +126,17 @@ class BtrFSRsyncConfig(BaseConfig):
         return folders
 
     @field_validator("Files", mode="before")
-    def expand_tilde_in_file_sources(cls, files) -> list[str]:
+    def expand_tilde_in_file_sources(cls, files: t.Iterable[str]) -> list[str]:
         new = [str(Path(cur).expanduser()) for cur in files]
         return new
 
     @field_validator("Folders", mode="before")
-    def expand_tilde_in_folder_sources(cls, folders) -> dict[str, str]:
+    def expand_tilde_in_folder_sources(cls, folders: dict[str, str]) -> dict[str, str]:
         new = {str(Path(src).expanduser()): dest for src, dest in folders.items()}
         return new
 
     @model_validator(mode="after")
-    def files_dest_is_no_folder_dest(self):
+    def files_dest_is_no_folder_dest(self) -> t.Self:
         files_dest = self.FilesDest
         destinations = self.Folders.values()
         if files_dest in destinations:
@@ -169,7 +169,7 @@ class ResticConfig(BaseConfig):
     RepositoryPassCmd: str
 
     @field_validator("FilesAndFolders", mode="before")
-    def expand_tilde_in_sources(cls, files_and_folders) -> set[str]:
+    def expand_tilde_in_sources(cls, files_and_folders: t.Iterable[str]) -> set[str]:
         new = {str(Path(src).expanduser()) for src in files_and_folders}
         return new
 

--- a/projects/butter-backup/tests/cli/test_cli_commands.py
+++ b/projects/butter-backup/tests/cli/test_cli_commands.py
@@ -414,10 +414,12 @@ def test_format_device_chowns_filesystem_to_user(
     assert len(config_lst) == 1
     config = config_lst[0]
 
-    with sdm.decrypted_device(big_file, config.DevicePassCmd) as decrypted:
-        with sdm.mounted_device(decrypted) as mounted:
-            owner = mounted.owner()
-            group = mounted.group()
+    with (
+        sdm.decrypted_device(big_file, config.DevicePassCmd) as decrypted,
+        sdm.mounted_device(decrypted) as mounted,
+    ):
+        owner = mounted.owner()
+        group = mounted.group()
     expected_user = sh.get_user()
     expected_group = sh.get_group(expected_user)
     assert owner == expected_user

--- a/projects/butter-backup/tests/config_parser/test_btrfs_config.py
+++ b/projects/butter-backup/tests/config_parser/test_btrfs_config.py
@@ -37,15 +37,14 @@ def test_btrfs_config_rejects_file_dest_collision(base_config, dest_dir: str):
 @given(base_config=valid_unparsed_empty_btrfs_config(), file_name=hu.filenames())
 def test_btrfs_config_rejects_filename_collision(base_config, file_name: str):
     base_config["Folders"] = {}
-    with TemporaryDirectory() as td1:
-        with TemporaryDirectory() as td2:
-            dirs = [td1, td2]
-            files = [Path(cur_dir) / file_name for cur_dir in dirs]
-            for f in files:
-                f.touch()
-            base_config["Files"] = [str(f) for f in files]
-            with pytest.raises(ValidationError, match=re.escape(file_name)):
-                cp.BtrFSRsyncConfig.model_validate(base_config)
+    with TemporaryDirectory() as td1, TemporaryDirectory() as td2:
+        dirs = [td1, td2]
+        files = [Path(cur_dir) / file_name for cur_dir in dirs]
+        for f in files:
+            f.touch()
+        base_config["Files"] = [str(f) for f in files]
+        with pytest.raises(ValidationError, match=re.escape(file_name)):
+            cp.BtrFSRsyncConfig.model_validate(base_config)
 
 
 @given(base_config=valid_unparsed_empty_btrfs_config())
@@ -75,18 +74,17 @@ def test_btrfs_config_expands_user(base_config):
     folder_dest=hu.filenames(),
 )
 def test_btrfs_config_rejects_duplicate_dest(base_config, folder_dest: str):
-    with TemporaryDirectory() as src1:
-        with TemporaryDirectory() as src2:
-            folders = {
-                "/usr/bin": "backup_bins",
-                src1: folder_dest,
-                "/var/log": "backup_logs",
-                src2: folder_dest,
-            }
-            base_config["Folders"] = folders
-            base_config["Files"] = []
-            with pytest.raises(ValidationError, match=re.escape(folder_dest)):
-                cp.BtrFSRsyncConfig.model_validate(base_config)
+    with TemporaryDirectory() as src1, TemporaryDirectory() as src2:
+        folders = {
+            "/usr/bin": "backup_bins",
+            src1: folder_dest,
+            "/var/log": "backup_logs",
+            src2: folder_dest,
+        }
+        base_config["Folders"] = folders
+        base_config["Files"] = []
+        with pytest.raises(ValidationError, match=re.escape(folder_dest)):
+            cp.BtrFSRsyncConfig.model_validate(base_config)
 
 
 @given(base_config=valid_unparsed_empty_btrfs_config())
@@ -183,13 +181,12 @@ def test_btrfs_config_accepts_valid_lzo(base_config) -> None:
 @given(base_config=valid_unparsed_empty_btrfs_config(), folder_dest=hu.filenames())
 def test_btrfs_config_json_roundtrip(base_config, folder_dest: str):
     assume(folder_dest != base_config["FilesDest"])
-    with TemporaryDirectory() as src_folder:
-        with NamedTemporaryFile() as src_file:
-            base_config["Folders"] = {src_folder: folder_dest}
-            base_config["Files"] = [src_file.name]
-            cfg = cp.BtrFSRsyncConfig.model_validate(base_config)
-            as_json = cfg.model_dump_json()
-            deserialised = cp.BtrFSRsyncConfig.model_validate_json(as_json)
+    with TemporaryDirectory() as src_folder, NamedTemporaryFile() as src_file:
+        base_config["Folders"] = {src_folder: folder_dest}
+        base_config["Files"] = [src_file.name]
+        cfg = cp.BtrFSRsyncConfig.model_validate(base_config)
+        as_json = cfg.model_dump_json()
+        deserialised = cp.BtrFSRsyncConfig.model_validate_json(as_json)
     assert cfg == deserialised
 
 

--- a/projects/butter-backup/tests/config_parser/test_restic_config.py
+++ b/projects/butter-backup/tests/config_parser/test_restic_config.py
@@ -74,12 +74,11 @@ def test_restic_config_device_ends_in_uuid(base_config) -> None:
 
 @given(base_config=valid_unparsed_empty_restic_config())
 def test_restic_config_json_roundtrip(base_config):
-    with TemporaryDirectory() as src_folder:
-        with NamedTemporaryFile() as src_file:
-            base_config["FilesAndFolders"] = {src_folder, src_file.name}
-            cfg = cp.ResticConfig.model_validate(base_config)
-            as_json = cfg.model_dump_json()
-            deserialised = cp.ResticConfig.model_validate_json(as_json)
+    with TemporaryDirectory() as src_folder, NamedTemporaryFile() as src_file:
+        base_config["FilesAndFolders"] = {src_folder, src_file.name}
+        cfg = cp.ResticConfig.model_validate(base_config)
+        as_json = cfg.model_dump_json()
+        deserialised = cp.ResticConfig.model_validate_json(as_json)
     assert cfg == deserialised
 
 

--- a/projects/butter-backup/tests/conftest.py
+++ b/projects/butter-backup/tests/conftest.py
@@ -119,15 +119,17 @@ def encrypted_device(request) -> cp.DeviceConfiguration:
 @pytest.fixture
 def mounted_device(encrypted_device) -> t.Iterator[tuple[cp.DeviceConfiguration, Path]]:
     config = encrypted_device
-    with sdm.decrypted_device(config.device(), config.DevicePassCmd) as decrypted:
-        with sdm.mounted_device(decrypted, config.compression()) as mounted_device:
-            if isinstance(config, cp.BtrFSRsyncConfig):
-                # Ensure `FilesDest` is a file, initially. This ensures correct handling
-                # of single files backup, even if an existing backup suffered from the
-                # erroneous behaviour of making FilesDest a file.
-                complemented = complement_configuration(config, Path("."))
-                backup_root = mounted_device / complemented.BackupRepositoryFolder
-                source_snapshot = bb.BtrFSRsyncBackend.get_source_snapshot(backup_root)
-                files_dest = source_snapshot / complemented.FilesDest
-                files_dest.touch()
-            yield config, mounted_device
+    with (
+        sdm.decrypted_device(config.device(), config.DevicePassCmd) as decrypted,
+        sdm.mounted_device(decrypted, config.compression()) as mounted_device,
+    ):
+        if isinstance(config, cp.BtrFSRsyncConfig):
+            # Ensure `FilesDest` is a file, initially. This ensures correct handling
+            # of single files backup, even if an existing backup suffered from the
+            # erroneous behaviour of making FilesDest a file.
+            complemented = complement_configuration(config, Path("."))
+            backup_root = mounted_device / complemented.BackupRepositoryFolder
+            source_snapshot = bb.BtrFSRsyncBackend.get_source_snapshot(backup_root)
+            files_dest = source_snapshot / complemented.FilesDest
+            files_dest.touch()
+        yield config, mounted_device

--- a/projects/shell-interface/pyproject.toml
+++ b/projects/shell-interface/pyproject.toml
@@ -31,14 +31,6 @@ dev = [
 ]
 typecheck = ["pydantic"]
 
-[tool.pytest.ini_options]
-addopts = [
-    "--cov", "src",
-    "--cov-branch",
-    "--cov-fail-under", "75"
-]
-testpaths = ["tests"]
-
 [tool.ruff]
 src = [".", "src/"]
 

--- a/projects/shell-interface/pyproject.toml
+++ b/projects/shell-interface/pyproject.toml
@@ -29,15 +29,7 @@ dev = [
     "pytest-cov>=7.1.0",
     "ruff>=0.15.12",
 ]
-
-[tool.mypy]
-allow_any_unimported = false
-warn_unreachable = true
-enable_error_code = [
-    "possibly-undefined"
-]
-strict = true
-
+typecheck = ["pydantic"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/projects/shell-interface/pyproject.toml
+++ b/projects/shell-interface/pyproject.toml
@@ -33,11 +33,7 @@ typecheck = ["pydantic"]
 
 [tool.ruff]
 src = [".", "src/"]
-
-[tool.ruff.lint]
-select = ["A", "B", "C", "F", "I", "ISC", "PIE", "PL", "Q", "RUF", "SIM", "TID", "W", "YTT"]
-ignore = ["E"]
-mccabe.max-complexity = 6
+extend = "../../pyproject.toml"
 
 [build-system]
 requires = ["hatchling"]

--- a/projects/storage-device-managers/pyproject.toml
+++ b/projects/storage-device-managers/pyproject.toml
@@ -35,23 +35,8 @@ dev = [
     "pytest-xdist>=3.8.0",
     "ruff>=0.15.7",
 ]
+typecheck = ["pydantic"]
 
-[tool.mypy]
-allow_any_unimported = false
-warn_unreachable = true
-enable_error_code = [
-    "possibly-undefined"
-]
-strict = true
-
-
-[[tool.mypy.overrides]]
-module = "tests.*"
-allow_incomplete_defs = true
-allow_untyped_defs = true
-disable_error_code = [
-    "possibly-undefined"
-]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/projects/storage-device-managers/pyproject.toml
+++ b/projects/storage-device-managers/pyproject.toml
@@ -38,14 +38,6 @@ dev = [
 typecheck = ["pydantic"]
 
 
-[tool.pytest.ini_options]
-addopts = [
-    "--cov", "src",
-    "--cov-branch",
-    "--cov-fail-under", "85"
-]
-testpaths = ["tests"]
-
 [tool.ruff]
 src = [".", "src/"]
 

--- a/projects/storage-device-managers/pyproject.toml
+++ b/projects/storage-device-managers/pyproject.toml
@@ -40,11 +40,8 @@ typecheck = ["pydantic"]
 
 [tool.ruff]
 src = [".", "src/"]
+extend = "../../pyproject.toml"
 
-[tool.ruff.lint]
-select = ["A", "B", "C", "F", "I", "ISC", "PIE", "PL", "Q", "RUF", "SIM", "TID", "W", "YTT"]
-ignore = ["E", "SIM117"]
-mccabe.max-complexity = 6
 
 [tool.uv.sources]
 shell-interface = { workspace = true }

--- a/projects/storage-device-managers/tests/conftest.py
+++ b/projects/storage-device-managers/tests/conftest.py
@@ -25,11 +25,10 @@ def device_with_fs(request) -> tuple[Path, sdm.ValidFileSystems]:
 
 @pytest.fixture
 def mounted_directories():
-    with TemporaryDirectory() as src:
-        with TemporaryDirectory() as mountpoint:
-            sh.run_cmd(cmd=["sudo", "mount", "-o", "bind", src, mountpoint])
-            yield Path(src), Path(mountpoint)
-            sh.run_cmd(cmd=["sudo", "umount", mountpoint])
+    with TemporaryDirectory() as src, TemporaryDirectory() as mountpoint:
+        sh.run_cmd(cmd=["sudo", "mount", "-o", "bind", src, mountpoint])
+        yield Path(src), Path(mountpoint)
+        sh.run_cmd(cmd=["sudo", "umount", mountpoint])
 
 
 @pytest.fixture(scope="session")

--- a/projects/storage-device-managers/tests/test_chown.py
+++ b/projects/storage-device-managers/tests/test_chown.py
@@ -25,10 +25,12 @@ def directory_with_content(tmp_path):
 
 
 def test_chown_raises_valueerror():
-    with pytest.raises(ValueError, match=r"directory.*recursive"):
-        with NamedTemporaryFile() as temp_file:
-            file = Path(temp_file.name)
-            sdm.chown(file, file.owner(), recursive=True)
+    with (
+        pytest.raises(ValueError, match=r"directory.*recursive"),
+        NamedTemporaryFile() as temp_file,
+    ):
+        file = Path(temp_file.name)
+        sdm.chown(file, file.owner(), recursive=True)
 
 
 def test_chown_file(directory_with_content):

--- a/projects/storage-device-managers/tests/test_device_manager.py
+++ b/projects/storage-device-managers/tests/test_device_manager.py
@@ -35,9 +35,11 @@ def test_decrypted_device_raises_devicedecryptionerror() -> None:
     pass_cmd = sdm.generate_passcmd()
     with NamedTemporaryFile() as named_temp_file:
         device = Path(named_temp_file.name)
-        with pytest.raises(sdm.DeviceDecryptionError):
-            with sdm.decrypted_device(device=device, pass_cmd=pass_cmd):
-                pass
+        with (
+            pytest.raises(sdm.DeviceDecryptionError),
+            sdm.decrypted_device(device=device, pass_cmd=pass_cmd),
+        ):
+            pass
 
 
 def test_decrypt_device_roundtrip(encrypted_device) -> None:
@@ -66,9 +68,11 @@ def test_decrypted_device(encrypted_device) -> None:
 
 def test_decrypted_device_closes_in_case_of_exception(encrypted_device) -> None:
     device, pass_cmd = encrypted_device
-    with pytest.raises(MyCustomTestException):
-        with sdm.decrypted_device(device=device, pass_cmd=pass_cmd) as dd:
-            raise MyCustomTestException
+    with (
+        pytest.raises(MyCustomTestException),
+        sdm.decrypted_device(device=device, pass_cmd=pass_cmd) as dd,
+    ):
+        raise MyCustomTestException
     assert not dd.exists()
 
 
@@ -94,17 +98,15 @@ def test_decrypted_device_can_use_home_for_passcmd(encrypted_device) -> None:
 def test_symbolic_link_rejects_existing_dest(tmp_path: Path) -> None:
     with NamedTemporaryFile() as named_file:
         source = Path(named_file.name)
-        with pytest.raises(FileExistsError):
-            with sdm.symbolic_link(source, dest=tmp_path):
-                pass
+        with pytest.raises(FileExistsError), sdm.symbolic_link(source, dest=tmp_path):
+            pass
 
 
 def test_symbolic_link_rejects_missing_src() -> None:
     src = Path(get_random_filename())
     dest = Path(get_random_filename())
-    with pytest.raises(FileNotFoundError):
-        with sdm.symbolic_link(src=src, dest=dest):
-            pass
+    with pytest.raises(FileNotFoundError), sdm.symbolic_link(src=src, dest=dest):
+        pass
 
 
 def test_symbolic_link() -> None:
@@ -121,14 +123,13 @@ def test_symbolic_link() -> None:
 
 
 def test_symbolic_link_removes_link_in_case_of_exception() -> None:
-    with pytest.raises(MyCustomTestException):
-        with NamedTemporaryFile() as src_f:
-            source = Path(src_f.name)
-            dest_p = Path(get_random_filename())
-            assert not os.path.lexists(dest_p)
-            with sdm.symbolic_link(src=source, dest=dest_p):
-                assert os.path.lexists(dest_p)
-                raise MyCustomTestException
+    with pytest.raises(MyCustomTestException), NamedTemporaryFile() as src_f:
+        source = Path(src_f.name)
+        dest_p = Path(get_random_filename())
+        assert not os.path.lexists(dest_p)
+        with sdm.symbolic_link(src=source, dest=dest_p):
+            assert os.path.lexists(dest_p)
+            raise MyCustomTestException
     assert not os.path.lexists(dest_p)
 
 
@@ -190,9 +191,11 @@ def test_decrypted_device_raises_passcmderror_on_bad_pass_cmd(
 ) -> None:
     device, _ = encrypted_device
     bad_pass_cmd = "exit 1"
-    with pytest.raises(sh.PassCmdError):
-        with sdm.decrypted_device(device=device, pass_cmd=bad_pass_cmd):
-            pass
+    with (
+        pytest.raises(sh.PassCmdError),
+        sdm.decrypted_device(device=device, pass_cmd=bad_pass_cmd),
+    ):
+        pass
 
 
 def test_encrypt_device_raises_passcmderror_on_bad_pass_cmd(big_file) -> None:

--- a/projects/storage-device-managers/tests/test_mount_unmount.py
+++ b/projects/storage-device-managers/tests/test_mount_unmount.py
@@ -77,20 +77,21 @@ def test_mounted_device_fails_on_not_unmountable_device() -> None:
         raise ValueError("No device mounted on / was found.")
 
     root = get_root_device()
-    with pytest.raises(sdm.UnmountError):
-        with sdm.mounted_device(root):
-            pass
+    with pytest.raises(sdm.UnmountError), sdm.mounted_device(root):
+        pass
 
 
 def test_mounted_device_unmounts_in_case_of_exception(
     device_with_fs, compression_args
 ) -> None:
     device, _ = device_with_fs
-    with pytest.raises(MyCustomTestException):
-        with sdm.mounted_device(device, *compression_args) as md:
-            # That the device is mounted properly is guaranteed by a test
-            # above.
-            raise MyCustomTestException
+    with (
+        pytest.raises(MyCustomTestException),
+        sdm.mounted_device(device, *compression_args) as md,
+    ):
+        # That the device is mounted properly is guaranteed by a test
+        # above.
+        raise MyCustomTestException
     assert not sdm.is_mounted(device), "Device is still mounted after exception."
     assert not md.exists(), "Mounted device still exists after exception."
     assert str(device) not in sdm.get_mounted_devices()
@@ -118,9 +119,8 @@ def test_unmount_device_raises_unmounterror() -> None:
     # This test calls unmount_device on a Path that is not mounted, which will cause
     # `umount` to fail. On such a failure, unmount_device is expected to raise an
     # UnmountError, which is what this test checks for.
-    with TemporaryDirectory() as mountpoint:
-        with pytest.raises(sdm.UnmountError):
-            sdm.unmount_device(Path(mountpoint))
+    with TemporaryDirectory() as mountpoint, pytest.raises(sdm.UnmountError):
+        sdm.unmount_device(Path(mountpoint))
 
 
 def test_mounted_device_does_not_delete_content_on_umount_error(
@@ -133,11 +133,13 @@ def test_mounted_device_does_not_delete_content_on_umount_error(
     )
     user = sh.get_user()
     sentinel_text = "This file should not be deleted."
-    with pytest.raises(sdm.UnmountError, match="Mocked unmount error"):
-        with sdm.mounted_device(device, *compression_args) as md:
-            sentinel = md / "sentinel-file"
-            sdm.chown(md, user, recursive=True)
-            sentinel.write_text("This file should not be deleted.")
+    with (
+        pytest.raises(sdm.UnmountError, match="Mocked unmount error"),
+        sdm.mounted_device(device, *compression_args) as md,
+    ):
+        sentinel = md / "sentinel-file"
+        sdm.chown(md, user, recursive=True)
+        sentinel.write_text("This file should not be deleted.")
     assert sentinel.exists(), "Sentinel file was deleted after unmount error."
     assert sentinel.read_text() == sentinel_text
     assert sdm.is_mounted(device)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,8 @@ addopts = [
     "--cov-fail-under", "85"
 ]
 testpaths = ["tests"]
+
+[tool.ruff.lint]
+select = ["A", "B", "C", "F", "I", "ISC", "PIE", "PL", "Q", "RUF", "SIM", "TID", "W", "YTT"]
+ignore = ["E"]
+mccabe.max-complexity = 6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,22 @@ dependencies = []
 
 [tool.uv.workspace]
 members = ["projects/*"]
+
+[tool.mypy]
+plugins = [
+  "pydantic.mypy"
+]
+allow_any_unimported = false
+warn_unreachable = true
+enable_error_code = [
+    "possibly-undefined"
+]
+strict = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+allow_incomplete_defs = true
+allow_untyped_defs = true
+disable_error_code = [
+    "possibly-undefined"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,22 @@ addopts = [
 testpaths = ["tests"]
 
 [tool.ruff.lint]
-select = ["A", "B", "C", "F", "I", "ISC", "PIE", "PL", "Q", "RUF", "SIM", "TID", "W", "YTT"]
-ignore = ["E"]
+select = [
+    "A",
+    "B",
+    "C",
+    "E",
+    "F",
+    "I",
+    "ISC",
+    "PIE",
+    "PL",
+    "Q",
+    "RUF",
+    "SIM",
+    "TID",
+    "W",
+    "YTT",
+]
+ignore = ["E501"]
 mccabe.max-complexity = 6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,11 @@ allow_untyped_defs = true
 disable_error_code = [
     "possibly-undefined"
 ]
+
+[tool.pytest.ini_options]
+addopts = [
+    "--cov", "src",
+    "--cov-branch",
+    "--cov-fail-under", "85"
+]
+testpaths = ["tests"]


### PR DESCRIPTION
Centralising common configuration reduces maintenance effort and
opens the opportunity to converge on a stricter configuration for
all workspace projects.

This MR implements that centralisation using uv workspaces.