### PR TITLE
Apply minor modernisations

### DIFF
--- a/projects/butter-backup/src/butter_backup/cli.py
+++ b/projects/butter-backup/src/butter_backup/cli.py
@@ -135,7 +135,7 @@ def _skip_device(
 
 
 CONFIG_OPTION = typer.Option(exists=True, dir_okay=False)
-VERBOSITY_OPTION = typer.Option(0, "--verbose", "-v", count=True)
+VERBOSITY_OPTION = typer.Option("--verbose", "-v", count=True)
 
 
 def _open_device(
@@ -164,7 +164,7 @@ def _open_device(
 def open(  # noqa: A001
     dest: t.Annotated[Path | None, typer.Argument()] = None,
     config: t.Annotated[Path | None, CONFIG_OPTION] = None,
-    verbose: int = VERBOSITY_OPTION,
+    verbose: t.Annotated[int, VERBOSITY_OPTION] = 0,
 ) -> None:
     """
     Öffne alle in der Konfiguration gelisteten Speichermedien
@@ -201,7 +201,7 @@ def open(  # noqa: A001
 @app.command()
 def close(
     config: t.Annotated[Path | None, CONFIG_OPTION] = None,
-    verbose: int = VERBOSITY_OPTION,
+    verbose: t.Annotated[int, VERBOSITY_OPTION] = 0,
 ) -> None:
     """
     Schließe alle geöffneten Speichermedien
@@ -235,7 +235,7 @@ def close(
 @app.command()
 def backup(
     config: t.Annotated[Path | None, CONFIG_OPTION] = None,
-    verbose: int = VERBOSITY_OPTION,
+    verbose: t.Annotated[int, VERBOSITY_OPTION] = 0,
 ) -> None:
     """
     Führe Sicherheitskopien durch
@@ -303,7 +303,7 @@ def format_device(
             " angegeben, wird die Konfiguration auf STDOUT ausgegeben.",
         ),
     ] = None,
-    verbose: int = VERBOSITY_OPTION,
+    verbose: t.Annotated[int, VERBOSITY_OPTION] = 0,
 ) -> None:
     """
     Richtet Speichermedium für butter-backup ein

--- a/projects/butter-backup/src/butter_backup/cli.py
+++ b/projects/butter-backup/src/butter_backup/cli.py
@@ -161,7 +161,7 @@ def _open_device(
 
 @app.command()
 def open(  # noqa: A001
-    dest: Path | None = typer.Argument(None),  # noqa: B008
+    dest: t.Annotated[Path | None, typer.Argument()] = None,
     config: Path | None = CONFIG_OPTION,
     verbose: int = VERBOSITY_OPTION,
 ) -> None:
@@ -278,22 +278,26 @@ def backup(
 
 @app.command()
 def format_device(
-    backend: ValidBackends = typer.Argument(...),  # noqa: B008
-    device: Path = typer.Argument(  # noqa: B008
-        ..., exists=True, dir_okay=False, readable=False
-    ),
-    file_system: ValidFileSystems | None = typer.Option(  # noqa: B008
-        None,
-        "--file-system",
-        help="Dateisystem für das Restic-Backend. Andere Werte als `btrfs` nur für das"
-        "Restic-Backend gültig. Unterstützte Dateisysteme: btrfs, ext4.",
-    ),
-    config_to: Path | None = typer.Option(  # noqa: B008
-        None,
-        help="Datei, in welche die generierte Konfiguration geschrieben werden"
-        " soll. Die angegebene Datei darf nicht existieren. Wenn nicht"
-        " angegeben, wird die Konfiguration auf STDOUT ausgegeben.",
-    ),
+    backend: t.Annotated[ValidBackends, typer.Argument()],
+    device: t.Annotated[
+        Path, typer.Argument(exists=True, dir_okay=False, readable=False)
+    ],
+    file_system: t.Annotated[
+        ValidFileSystems | None,
+        typer.Option(
+            "--file-system",
+            help="Dateisystem für das Restic-Backend. Andere Werte als `btrfs` nur für das"
+            "Restic-Backend gültig. Unterstützte Dateisysteme: btrfs, ext4.",
+        ),
+    ] = None,
+    config_to: t.Annotated[
+        Path | None,
+        typer.Option(
+            help="Datei, in welche die generierte Konfiguration geschrieben werden"
+            " soll. Die angegebene Datei darf nicht existieren. Wenn nicht"
+            " angegeben, wird die Konfiguration auf STDOUT ausgegeben.",
+        ),
+    ] = None,
     verbose: int = VERBOSITY_OPTION,
 ) -> None:
     """

--- a/projects/butter-backup/src/butter_backup/cli.py
+++ b/projects/butter-backup/src/butter_backup/cli.py
@@ -134,7 +134,7 @@ def _skip_device(
     return False
 
 
-CONFIG_OPTION = typer.Option(None, exists=True, dir_okay=False)
+CONFIG_OPTION = typer.Option(exists=True, dir_okay=False)
 VERBOSITY_OPTION = typer.Option(0, "--verbose", "-v", count=True)
 
 
@@ -163,7 +163,7 @@ def _open_device(
 @app.command()
 def open(  # noqa: A001
     dest: t.Annotated[Path | None, typer.Argument()] = None,
-    config: Path | None = CONFIG_OPTION,
+    config: t.Annotated[Path | None, CONFIG_OPTION] = None,
     verbose: int = VERBOSITY_OPTION,
 ) -> None:
     """
@@ -199,7 +199,10 @@ def open(  # noqa: A001
 
 
 @app.command()
-def close(config: Path | None = CONFIG_OPTION, verbose: int = VERBOSITY_OPTION) -> None:
+def close(
+    config: t.Annotated[Path | None, CONFIG_OPTION] = None,
+    verbose: int = VERBOSITY_OPTION,
+) -> None:
     """
     Schließe alle geöffneten Speichermedien
 
@@ -231,7 +234,8 @@ def close(config: Path | None = CONFIG_OPTION, verbose: int = VERBOSITY_OPTION) 
 
 @app.command()
 def backup(
-    config: Path | None = CONFIG_OPTION, verbose: int = VERBOSITY_OPTION
+    config: t.Annotated[Path | None, CONFIG_OPTION] = None,
+    verbose: int = VERBOSITY_OPTION,
 ) -> None:
     """
     Führe Sicherheitskopien durch

--- a/projects/butter-backup/src/butter_backup/cli.py
+++ b/projects/butter-backup/src/butter_backup/cli.py
@@ -5,9 +5,10 @@ import json
 import os
 import sys
 import typing as t
+from collections.abc import Callable
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Any, Callable
+from typing import Any
 
 import shell_interface as sh
 import storage_device_managers as sdm

--- a/projects/butter-backup/tests/test_backup_backends.py
+++ b/projects/butter-backup/tests/test_backup_backends.py
@@ -3,9 +3,10 @@ import itertools
 import os
 import typing as t
 from collections import Counter
+from collections.abc import Iterable
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Iterable, overload
+from typing import overload
 from uuid import uuid4
 
 import pytest

--- a/projects/shell-interface/src/shell_interface/shell_interface.py
+++ b/projects/shell-interface/src/shell_interface/shell_interface.py
@@ -5,7 +5,6 @@ import os
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
-from typing import List, Optional, Union
 
 try:
     from loguru import logger  # type: ignore[import, unused-ignore]
@@ -16,8 +15,8 @@ except ModuleNotFoundError:
     logger.debug = lambda msg: None  # type: ignore[assignment, unused-ignore]
     logger.error = lambda msg: None  # type: ignore[assignment, unused-ignore]
 
-StrPathList = List[Union[str, Path]]
-_CMD_LIST = Union[List[str], List[Path], StrPathList]
+StrPathList = list[str | Path]
+_CMD_LIST = list[str] | list[Path] | StrPathList
 
 
 class PassCmdError(RuntimeError):
@@ -31,7 +30,7 @@ class ShellInterfaceError(RuntimeError):
 def run_cmd(
     *,
     cmd: _CMD_LIST,
-    env: Optional[dict[str, str]] = None,
+    env: dict[str, str] | None = None,
     capture_output: bool = False,
 ) -> subprocess.CompletedProcess[bytes]:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ select = [
     "C",
     "E",
     "F",
+    "FURB",
     "I",
     "ISC",
     "PIE",
@@ -49,6 +50,7 @@ select = [
     "RUF",
     "SIM",
     "TID",
+    "UP",
     "W",
     "YTT",
 ]


### PR DESCRIPTION
This MR activates the rule sets UP and FURB. Furthermore, it rewrites
the option handling in the CLI to use `t.Annotated`, which gets rid
of the annoying type-wrong default value assignments.