### PR TITLE
Fix detection of mount points with spaces

### DIFF
--- a/projects/storage-device-managers/pyproject.toml
+++ b/projects/storage-device-managers/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 license = "GPL-3.0-or-later"
 dependencies = [
     "loguru>=0.7.3",
+    "msgspec>=0.21.1",
     "shell-interface",
 ]
 requires-python = ">=3.11"

--- a/projects/storage-device-managers/src/storage_device_managers/__init__.py
+++ b/projects/storage-device-managers/src/storage_device_managers/__init__.py
@@ -4,15 +4,15 @@ import secrets
 import string
 import tempfile
 import typing as t
-from collections import defaultdict
 from collections.abc import Iterator
 from importlib import metadata
 from pathlib import Path
 from types import SimpleNamespace
 from uuid import UUID, uuid4
 
-import msgspec
 import shell_interface as sh
+
+from storage_device_managers._findmnt import MountOptions, get_mounted_devices
 
 try:
     from loguru import logger  # type: ignore[import, unused-ignore]
@@ -50,7 +50,6 @@ __all__ = [
     "unmount_device",
 ]
 
-MountOptions = frozenset[str]
 ValidFileSystems = t.Literal["btrfs", "ext4"]
 
 
@@ -403,53 +402,6 @@ def is_mounted(device: Path) -> bool:
         logger.info(f"Kein Mountpunkt für Speichermedium {device} gefunden.")
         return False
     return True
-
-
-class _FindmntFilesystem(msgspec.Struct):
-    source: str
-    target: str
-    options: str
-    fstype: str = ""
-
-
-class _FindmntOutput(msgspec.Struct):
-    filesystems: list[_FindmntFilesystem]
-
-
-def get_mounted_devices() -> t.Mapping[str, t.Mapping[Path, MountOptions]]:
-    """Get all mounted devices
-
-    This function will parse the output of `findmnt -l --json` and return everything
-    that is mounted to somewhere. The returned mapping maps device names (i.e. mount
-    sources) to their destinations and mount options.
-
-    Since a source can be mounted to multiple (e.g. /dev/sda1 can be mounted to
-    /home/{user1,user2}/Videos), the value of the mapping is another mapping. This inner
-    mapping maps mount destinations to their mount options.
-
-    Returns:
-    --------
-    t.Mapping[str, t.Mapping[Path, MountOptions]]
-        A mapping that maps mount sources (i.e. device names) to their
-        destinations and mount options.
-
-    Example Return Value:
-    ---------------------
-    {
-        "/dev/nvme0n1p2": {
-            Path("/boot"): frozenset({"rw", "relatime"}),
-            Path("/media/backup"): frozenset({"rw", "relatime", "compress=zstd:3"}),
-        },
-    }
-    """
-    raw = sh.run_cmd(cmd=["findmnt", "-l", "--json"], capture_output=True)
-    parsed = msgspec.json.decode(raw.stdout, type=_FindmntOutput)
-    mount_points: dict[str, dict[Path, MountOptions]] = defaultdict(dict)
-    for fs in parsed.filesystems:
-        dest = Path(fs.target)
-        options: MountOptions = frozenset(fs.options.split(","))
-        mount_points[fs.source][dest] = options
-    return dict(mount_points)
 
 
 def sync_device(device: Path) -> None:

--- a/projects/storage-device-managers/src/storage_device_managers/__init__.py
+++ b/projects/storage-device-managers/src/storage_device_managers/__init__.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from uuid import UUID, uuid4
 
+import msgspec
 import shell_interface as sh
 
 try:
@@ -404,12 +405,23 @@ def is_mounted(device: Path) -> bool:
     return True
 
 
+class _FindmntFilesystem(msgspec.Struct):
+    source: str
+    target: str
+    options: str
+    fstype: str = ""
+
+
+class _FindmntOutput(msgspec.Struct):
+    filesystems: list[_FindmntFilesystem]
+
+
 def get_mounted_devices() -> t.Mapping[str, t.Mapping[Path, MountOptions]]:
     """Get all mounted devices
 
-    This function will parse the output of `mount` and return everything that is mounted
-    to somewhere. The returned mapping maps device names (i.e. mount sources) to their
-    destinations and mount options.
+    This function will parse the output of `findmnt -l --json` and return everything
+    that is mounted to somewhere. The returned mapping maps device names (i.e. mount
+    sources) to their destinations and mount options.
 
     Since a source can be mounted to multiple (e.g. /dev/sda1 can be mounted to
     /home/{user1,user2}/Videos), the value of the mapping is another mapping. This inner
@@ -430,17 +442,13 @@ def get_mounted_devices() -> t.Mapping[str, t.Mapping[Path, MountOptions]]:
         },
     }
     """
-    # Example line:
-    # /dev/nvme0n1p2 on /boot type ext2 (rw,relatime)
-    raw_mounts = sh.run_cmd(cmd=["mount"], capture_output=True)
-    mount_lines = raw_mounts.stdout.decode().splitlines()
+    raw = sh.run_cmd(cmd=["findmnt", "-l", "--json"], capture_output=True)
+    parsed = msgspec.json.decode(raw.stdout, type=_FindmntOutput)
     mount_points: dict[str, dict[Path, MountOptions]] = defaultdict(dict)
-    for line in mount_lines:
-        device = line.split()[0]
-        dest = Path(line.split()[2])
-        raw_options = line.split()[5]
-        options = frozenset(raw_options.strip("()").split(","))
-        mount_points[device][dest] = options
+    for fs in parsed.filesystems:
+        dest = Path(fs.target)
+        options: MountOptions = frozenset(fs.options.split(","))
+        mount_points[fs.source][dest] = options
     return dict(mount_points)
 
 

--- a/projects/storage-device-managers/src/storage_device_managers/_findmnt.py
+++ b/projects/storage-device-managers/src/storage_device_managers/_findmnt.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import json
 import typing as t
 from collections import defaultdict
 from pathlib import Path
@@ -18,6 +17,22 @@ class _FindmntFilesystem(msgspec.Struct):
 
 class _FindmntOutput(msgspec.Struct):
     filesystems: list[_FindmntFilesystem]
+
+
+def _get_loop_device_backing_files() -> dict[str, str]:
+    """Return a mapping from loop device path to its backing file path.
+
+    Example return value:
+    {"/dev/loop3": "/tmp/tmpXXX", ...}
+
+    Returns an empty mapping if ``losetup`` is unavailable or reports no devices.
+    """
+    try:
+        raw = sh.run_cmd(cmd=["losetup", "--list", "--json"], capture_output=True)
+        data: dict[str, t.Any] = json.loads(raw.stdout)
+    except (sh.ShellInterfaceError, json.JSONDecodeError):
+        return {}
+    return {dev["name"]: dev["back-file"] for dev in data.get("loopdevices", [])}
 
 
 def get_mounted_devices() -> t.Mapping[str, t.Mapping[Path, MountOptions]]:
@@ -46,11 +61,15 @@ def get_mounted_devices() -> t.Mapping[str, t.Mapping[Path, MountOptions]]:
         },
     }
     """
-    raw = sh.run_cmd(cmd=["findmnt", "-l", "--json"], capture_output=True)
+    raw = sh.run_cmd(
+        cmd=["findmnt", "--list", "--json", "--nofsroot"], capture_output=True
+    )
     parsed = msgspec.json.decode(raw.stdout, type=_FindmntOutput)
+    loop_backing_mapping = _get_loop_device_backing_files()
     mount_points: dict[str, dict[Path, MountOptions]] = defaultdict(dict)
     for fs in parsed.filesystems:
+        source = loop_backing_mapping.get(fs.source, fs.source)
         dest = Path(fs.target)
         options: MountOptions = frozenset(fs.options.split(","))
-        mount_points[fs.source][dest] = options
+        mount_points[source][dest] = options
     return dict(mount_points)

--- a/projects/storage-device-managers/src/storage_device_managers/_findmnt.py
+++ b/projects/storage-device-managers/src/storage_device_managers/_findmnt.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import typing as t
+from collections import defaultdict
+from pathlib import Path
+
+import msgspec
+import shell_interface as sh
+
+MountOptions = frozenset[str]
+
+
+class _FindmntFilesystem(msgspec.Struct):
+    source: str
+    target: str
+    options: str
+    fstype: str = ""
+
+
+class _FindmntOutput(msgspec.Struct):
+    filesystems: list[_FindmntFilesystem]
+
+
+def get_mounted_devices() -> t.Mapping[str, t.Mapping[Path, MountOptions]]:
+    """Get all mounted devices
+
+    This function will parse the output of `findmnt -l --json` and return everything
+    that is mounted to somewhere. The returned mapping maps device names (i.e. mount
+    sources) to their destinations and mount options.
+
+    Since a source can be mounted to multiple (e.g. /dev/sda1 can be mounted to
+    /home/{user1,user2}/Videos), the value of the mapping is another mapping. This inner
+    mapping maps mount destinations to their mount options.
+
+    Returns:
+    --------
+    t.Mapping[str, t.Mapping[Path, MountOptions]]
+        A mapping that maps mount sources (i.e. device names) to their
+        destinations and mount options.
+
+    Example Return Value:
+    ---------------------
+    {
+        "/dev/nvme0n1p2": {
+            Path("/boot"): frozenset({"rw", "relatime"}),
+            Path("/media/backup"): frozenset({"rw", "relatime", "compress=zstd:3"}),
+        },
+    }
+    """
+    raw = sh.run_cmd(cmd=["findmnt", "-l", "--json"], capture_output=True)
+    parsed = msgspec.json.decode(raw.stdout, type=_FindmntOutput)
+    mount_points: dict[str, dict[Path, MountOptions]] = defaultdict(dict)
+    for fs in parsed.filesystems:
+        dest = Path(fs.target)
+        options: MountOptions = frozenset(fs.options.split(","))
+        mount_points[fs.source][dest] = options
+    return dict(mount_points)

--- a/projects/storage-device-managers/src/storage_device_managers/_findmnt.py
+++ b/projects/storage-device-managers/src/storage_device_managers/_findmnt.py
@@ -14,7 +14,6 @@ class _FindmntFilesystem(msgspec.Struct):
     source: str
     target: str
     options: str
-    fstype: str = ""
 
 
 class _FindmntOutput(msgspec.Struct):

--- a/projects/storage-device-managers/src/storage_device_managers/_findmnt.py
+++ b/projects/storage-device-managers/src/storage_device_managers/_findmnt.py
@@ -1,4 +1,3 @@
-import json
 import typing as t
 from collections import defaultdict
 from pathlib import Path
@@ -7,6 +6,15 @@ import msgspec
 import shell_interface as sh
 
 MountOptions = frozenset[str]
+
+
+class _LoSetupDevice(msgspec.Struct):
+    name: str
+    back_file: str = msgspec.field(name="back-file")
+
+
+class _LoSetupOutput(msgspec.Struct):
+    loopdevices: list[_LoSetupDevice]
 
 
 class _FindmntFilesystem(msgspec.Struct):
@@ -27,12 +35,9 @@ def _get_loop_device_backing_files() -> dict[str, str]:
 
     Returns an empty mapping if ``losetup`` is unavailable or reports no devices.
     """
-    try:
-        raw = sh.run_cmd(cmd=["losetup", "--list", "--json"], capture_output=True)
-        data: dict[str, t.Any] = json.loads(raw.stdout)
-    except (sh.ShellInterfaceError, json.JSONDecodeError):
-        return {}
-    return {dev["name"]: dev["back-file"] for dev in data.get("loopdevices", [])}
+    raw = sh.run_cmd(cmd=["losetup", "--list", "--json"], capture_output=True)
+    parsed = msgspec.json.decode(raw.stdout, type=_LoSetupOutput)
+    return {dev.name: dev.back_file for dev in parsed.loopdevices}
 
 
 def get_mounted_devices() -> t.Mapping[str, t.Mapping[Path, MountOptions]]:

--- a/projects/storage-device-managers/tests/test_get_mounted_devices.py
+++ b/projects/storage-device-managers/tests/test_get_mounted_devices.py
@@ -1,10 +1,27 @@
-from __future__ import annotations
-
+import typing as t
 from pathlib import Path
 
 import pytest
+import shell_interface as sh
 
 import storage_device_managers as sdm
+
+
+@pytest.fixture
+def mounted_directory_with_spaces(tmp_path: Path) -> t.Iterable[Path]:
+    src = tmp_path / "src"
+    src.mkdir()
+    mountpoint = tmp_path / "mount point with spaces"
+    mountpoint.mkdir()
+    # sdm.mounted_device cannot be used here because it checks for the filesystem type,
+    # which is not present on this mock directory.
+    mount_cmd: sh.StrPathList = ["sudo", "mount", "-o", "bind", src, mountpoint]
+    umount_cmd: sh.StrPathList = ["sudo", "umount", mountpoint]
+    sh.run_cmd(cmd=mount_cmd)
+    try:
+        yield mountpoint
+    finally:
+        sh.run_cmd(cmd=umount_cmd)
 
 
 def test_get_mounted_devices_raises_on_unknown_device() -> None:
@@ -26,3 +43,13 @@ def test_get_mounted_devices_includes_correct_mountpoints(mounted_directories) -
 
 def test_get_mounted_devices_includes_root() -> None:
     assert any(Path("/") in dest_set for dest_set in sdm.get_mounted_devices().values())
+
+
+def test_get_mounted_devices_handles_spaces_in_destination(
+    mounted_directory_with_spaces,
+) -> None:
+    mount_point = mounted_directory_with_spaces
+    all_mounts = sdm.get_mounted_devices()
+    all_mount_points = {cur for dest_set in all_mounts.values() for cur in dest_set}
+    errmsg = f"Expected mount point '{mount_point}' not found."
+    assert mount_point in all_mount_points, errmsg

--- a/uv.lock
+++ b/uv.lock
@@ -410,6 +410,54 @@ wheels = [
 ]
 
 [[package]]
+name = "msgspec"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/60/f79b9b013a16fa3a58350c9295ddc6789f2e335f36ea61ed10a21b215364/msgspec-0.21.1.tar.gz", hash = "sha256:2313508e394b0d208f8f56892ca9b2799e2561329de9763b19619595a6c0f72c", size = 319193, upload-time = "2026-04-12T21:44:50.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/7f/bbc4e74cd33d316b75541149e4d35b163b63bce066530ae185a2ec3b5bfc/msgspec-0.21.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b504b6e7f7a22a24b27232b73034421692147865162daaec9f3bf62439007c87", size = 193131, upload-time = "2026-04-12T21:43:56.094Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/60/504886af1aaf854112663b842d5eea9a15d9588f9bf7d0d2df736424b84d/msgspec-0.21.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4692b7c1609155708c4418f88e92f63c13fdf08aa095c84bae82bad75b53389b", size = 186597, upload-time = "2026-04-12T21:43:57.242Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/54/d24ddeaa65b5278c9e67f48ce3c17a9831e8f3722f3c8322ee120aca22ef/msgspec-0.21.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3124010b3815451494c85ff345e693cb9fe5889cfcbbef39ed8622e0e72319c", size = 215158, upload-time = "2026-04-12T21:43:58.442Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/75/bb79c8b89a93ae23cd33c0d802373f16feaf9633f05d8af77091350dda0a/msgspec-0.21.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6badc03b9725352219cca017bfe71c61f2fbd0fb5982b410ac17c97c213deb30", size = 219856, upload-time = "2026-04-12T21:44:00.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/c5ca26b46f0ebbd3a6683695ef89396712cb9e4199fd1f0bc1dd968216b1/msgspec-0.21.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5d2d4116ebe3035a78d9ec76e99a9d64e5fa6d44fe61a9c5de7fd1acf54bcc69", size = 220314, upload-time = "2026-04-12T21:44:01.548Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/31/645a351c4285dce40ed6755c3dcc0aa648e26dacb20a98018fe2cce5e87b/msgspec-0.21.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0d1009f6715f5bff3b54d4ff5c7428ad96197e0534e1645b8e9b955890c84664", size = 223215, upload-time = "2026-04-12T21:44:02.884Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8bf15736a6dd3cb4f90c5467f6dc39197d2daaf10754490cdc0aa17b7312/msgspec-0.21.1-cp311-cp311-win_amd64.whl", hash = "sha256:c6faffe5bb644ec884052679af4dfd776d4b5ca90e4a7ec7e7e319e4e6b93a6e", size = 188554, upload-time = "2026-04-12T21:44:04.151Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/29/cc7db3a165b62d16e64a83f82eccb79655055cb5bc1f60459a6f9d7c82f2/msgspec-0.21.1-cp311-cp311-win_arm64.whl", hash = "sha256:ee9e3f11fa94603f7d673bf795cfa31b549c4a2c723bc39b45beb1e7f5a3fb99", size = 174517, upload-time = "2026-04-12T21:44:05.66Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/cf/317224852c00248c620a9bcf4b26e2e4ab8afd752f18d2a6ef73ebd423b6/msgspec-0.21.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4248cf0b6129b7d230eacd493c17cc2d4f3989f3bb7f633a928a85b7dcfa251", size = 196188, upload-time = "2026-04-12T21:44:07.181Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/074612945c0666078f7366f40000013de9f6ba687491d450df699bceebc9/msgspec-0.21.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5102c7e9b3acff82178449b85006d96310e690291bb1ea0142f1b24bcb8aabcb", size = 188473, upload-time = "2026-04-12T21:44:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/37/655101799590bcc5fddb2bd3fe0e6194e816c2d1da7c361725f5eb89a910/msgspec-0.21.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846758412e9518252b2ac9bffd6f0e54d9ff614f5f9488df7749f81ff5c80920", size = 218871, upload-time = "2026-04-12T21:44:09.917Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d1/d4cd9fe89c7d400d7a18f86ccc94daa3f0927f53558846fcb60791dce5d6/msgspec-0.21.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21995e74b5c598c2e004110ad66ec7f1b8c20bf2bcf3b2de8fd9a3094422d3ff", size = 225025, upload-time = "2026-04-12T21:44:11.191Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bf/e20549e602b9edccadeeff98760345a416f9cce846a657e8b18e3396b212/msgspec-0.21.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6129f0cca52992e898fd5344187f7c8127b63d810b2fd73e36fca73b4c6475ee", size = 222672, upload-time = "2026-04-12T21:44:12.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/68/04d7a8f0f786545cf9b8c280c57aa6befb5977af6e884b8b54191cbe44b3/msgspec-0.21.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ef3ec2296248d1f8b9231acb051b6d471dfde8f21819e86c9adaaa9f42918521", size = 227303, upload-time = "2026-04-12T21:44:13.709Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4d/619866af2840875be408047bf9e70ceafbae6ab50660de7134ed1b25eb86/msgspec-0.21.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4ab834a054c6f0cbeef6df9e7e1b33d5f1bc7b86dea1d2fd7cad003873e783d", size = 190017, upload-time = "2026-04-12T21:44:14.977Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/a8f9eca8fd00e097d7a9e99ba8a4685db994494448e3d4f0b7f6e9a3c0f7/msgspec-0.21.1-cp312-cp312-win_arm64.whl", hash = "sha256:628aaa35c74950a8c59da330d7e98917e1c7188f983745782027748ee4ca573e", size = 175345, upload-time = "2026-04-12T21:44:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/74/f11ede02839b19ff459f88e3145df5d711626ca84da4e23520cebf819367/msgspec-0.21.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:764173717a01743f007e9f74520ed281f24672c604514f7d76c1c3a10e8edb66", size = 196176, upload-time = "2026-04-12T21:44:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/4476c1bd341418a046c4955aff632ec769315d1e3cb94e6acf86d461f9ed/msgspec-0.21.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:344c7cd0eaed1fb81d7959f99100ef71ec9b536881a376f11b9a6c4803365697", size = 188524, upload-time = "2026-04-12T21:44:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d9/9e9d7d7e5061b47540d03d640fab9b3965ba7ae49c1b2154861c8f007518/msgspec-0.21.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48943e278b3854c2f89f955ddc6f9f430d3f0784b16e47d10604ee0463cd21f5", size = 218880, upload-time = "2026-04-12T21:44:20.028Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/2bb344f34abb4b57e60c7c9c761994e0417b9718ec1460bf00c296f2a7ea/msgspec-0.21.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9aa659ebb0101b1cbc31461212b87e341d961f0ab0772aaf068a99e001ec4aa", size = 225050, upload-time = "2026-04-12T21:44:21.577Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/84/7c1e412f76092277bf760cef12b7979d03314d259ab5b5cafde5d0c1722d/msgspec-0.21.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7b27d1a8ead2b6f5b0c4f2d07b8be1ccfcc041c8a0e704781edebe3ae13c484", size = 222713, upload-time = "2026-04-12T21:44:22.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/27/0bba04b2b4ef05f3d068429410bc71d2cea925f1596a8f41152cccd5edb8/msgspec-0.21.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:38fe93e86b61328fe544cb7fd871fad5a27c8734bfda90f65e5dbe288ae50f61", size = 227259, upload-time = "2026-04-12T21:44:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2d/09574b0eea02fed2c2c1383dbaae2c7f79dc16dcd6487a886000afb5d7c4/msgspec-0.21.1-cp313-cp313-win_amd64.whl", hash = "sha256:8bc666331c35fcce05a7cd2d6221adbe0f6058f8e750711413d22793c080ac6a", size = 189857, upload-time = "2026-04-12T21:44:25.359Z" },
+    { url = "https://files.pythonhosted.org/packages/46/34/105b1576ad182879914f0c821f17ee1d13abb165cb060448f96fe2aff078/msgspec-0.21.1-cp313-cp313-win_arm64.whl", hash = "sha256:42bb1241e0750c1a4346f2aa84db26c5ffd99a4eb3a954927d9f149ff2f42898", size = 175403, upload-time = "2026-04-12T21:44:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ad/86954e987d1d6a5c579e2c2e7832b65e0fff194179fdac4f581536086024/msgspec-0.21.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fab48eb45fdbfbdb2c0edfec00ffc53b6b6085beefc6b50b61e01659f9f8757f", size = 196261, upload-time = "2026-04-12T21:44:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a1/c5e46c3e42b866199365e35d11dddfd1fbd8bba4fdb3c52f965b1607ce94/msgspec-0.21.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3cb779ea0c35bc807ff941d415875c1f69ca0be91a2e907ab99a171811d86a9a", size = 188729, upload-time = "2026-04-12T21:44:28.99Z" },
+    { url = "https://files.pythonhosted.org/packages/85/7d/1e29a319d678d6cb962ae5bdf32a6858ebdf38f73bc654c0e9c742a0c2c8/msgspec-0.21.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68604db36b3b4dd9bf160e436e12798a4738848144cea1aca1cb984011eb160f", size = 219866, upload-time = "2026-04-12T21:44:31.104Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d6b9dc50948eaf65df54d2fd0ff66e6d8c32f116037209ee861810eb9b676cb", size = 224993, upload-time = "2026-04-12T21:44:32.649Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/d2120fc9d419a89a3a7c13e5b7078798c4b392a96a02a6e2b3ce43a8766c/msgspec-0.21.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:52c5e21930942302394429c5a582ce7e6b62c7f983b3760834c2ce107e0dd6df", size = 223535, upload-time = "2026-04-12T21:44:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/75/17/42418b66a3ad972a89bab73dd78b79cc6282bb488a25e73c853cee7443b9/msgspec-0.21.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:abbb39d65681fa24ed394e01af3d59d869068324f900c61d06062b7fb9980f2f", size = 227222, upload-time = "2026-04-12T21:44:35.093Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/33/265c894268cca88ff67b144ca2b4c522fc8b9a6f1966a3640c70516e78e1/msgspec-0.21.1-cp314-cp314-win_amd64.whl", hash = "sha256:5666b1b560b97b6ec2eb3fca8a502298ebac56e13bbca1f88523538ce83d01ea", size = 193810, upload-time = "2026-04-12T21:44:36.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8f/a6d35f25bf1fc63c492fdd88fdce01ba0875ead48c2b91f90f33653b4131/msgspec-0.21.1-cp314-cp314-win_arm64.whl", hash = "sha256:d8b8578e4c83b14ceea4cef0d0b747e31d9330fe4b03b2b2ad4063866a178f93", size = 179125, upload-time = "2026-04-12T21:44:38.198Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/39/74839641e64b99d87da55af0fc472854d42b46e2183b9e2a67fe1bb2a512/msgspec-0.21.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15f523d51c00ebad412213bfe9f06f0a50ec2b93e0c19e824a2d267cabb48ea2", size = 200171, upload-time = "2026-04-12T21:44:39.414Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9b/ce0cca6d2d87fcd4b6ff97600790494e64f26a2c55d61507cd2755c16193/msgspec-0.21.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e47390360583ba3d5c6cb44cf0a9f61b0a06a899d3c2c00627cedebb2e2884b", size = 192879, upload-time = "2026-04-12T21:44:40.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/08/673a7bb05e5702dc787ddd3011195b509f9867927970da59052211929987/msgspec-0.21.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f60800e6299b798142dc40b0644da77ceac5ea0568be58228417eae14135c847", size = 226281, upload-time = "2026-04-12T21:44:42.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/86508cf57283e9070b3c447e3ab25b792a7a0855a3ea4e0c6d111ac34c97/msgspec-0.21.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f8e9dfcd98419cf7568808470c4317a3fb30bef0e3715b568730a2b272a20d7", size = 229863, upload-time = "2026-04-12T21:44:43.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/62/e7c9367cd08d590559faacd711edbae36840342843e669440363f33c7d36/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92d89dfad13bd1ea640dc3e37e724ed380da1030b272bdf5ecafb983c3ad7c75", size = 230445, upload-time = "2026-04-12T21:44:44.806Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b4/c0f54632103846b658a10930025f4de41c8724b5e4805a5f3b395586cb7e/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca", size = 231822, upload-time = "2026-04-12T21:44:46.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1d/0d85cc79d0ccf5508e9c846cc66552a6a16bf92abd1dbd8362617f7b35cd/msgspec-0.21.1-cp314-cp314t-win_amd64.whl", hash = "sha256:740fbf1c9d59992ca3537d6fbe9ebbf9eaf726a65fbf31448e0ecbc710697a63", size = 206650, upload-time = "2026-04-12T21:44:47.601Z" },
+    { url = "https://files.pythonhosted.org/packages/90/91/56c5d560f20e6c20e9e4f55bd0e458f7f162aa689ee350346c04c48eac0b/msgspec-0.21.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0d2cc73df6058d811a126ac3a8ad63a4dfa210c82f9cf5a004802eaf4712de90", size = 183149, upload-time = "2026-04-12T21:44:48.833Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -863,6 +911,7 @@ version = "2.0.0"
 source = { editable = "projects/storage-device-managers" }
 dependencies = [
     { name = "loguru" },
+    { name = "msgspec" },
     { name = "shell-interface" },
 ]
 
@@ -890,6 +939,7 @@ typecheck = [
 requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "loguru", marker = "extra == 'logging'" },
+    { name = "msgspec", specifier = ">=0.21.1" },
     { name = "shell-interface", editable = "projects/shell-interface" },
 ]
 provides-extras = ["logging"]


### PR DESCRIPTION
By switching to `findmnt --json`, mount destinations that use spaces
in their name are correctly parsed and picked up. In order to continue
to support the patterns used by the test suite, loopback devices are
mapped to their backing files or directories.